### PR TITLE
Emacs Daemon

### DIFF
--- a/resources/gnu.emacs.daemon.plist
+++ b/resources/gnu.emacs.daemon.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+ <plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>gnu.emacs.daemon</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/Users/adost/.nix-profile/bin/emacs</string>
+      <string>--daemon</string>
+    </array>
+   <key>RunAtLoad</key>
+   <true/>
+   <key>ServiceDescription</key>
+   <string>GNU Emacs Daemon</string>
+  </dict>
+</plist>

--- a/stow/emacs/.emacs.d/init.el
+++ b/stow/emacs/.emacs.d/init.el
@@ -295,7 +295,11 @@
                     :weight 'regular)
 
 ;; For icons used in various places
-(use-package all-the-icons)
+(use-package all-the-icons
+  :init
+  ;; Scale icons down slightly (default is 1.2) to allow room for DOOM modeline. See
+  ;; https://github.com/hlissner/doom-emacs/issues/2967#issuecomment-619319082 for more details.
+  (gsetq all-the-icons-scale-factor 1.1))
 
 ;;; Emacs file management
 

--- a/stow/emacs/.emacs.d/init.el
+++ b/stow/emacs/.emacs.d/init.el
@@ -922,7 +922,7 @@ Redefined to allow pop-up windows."
                            ((org-ql-block-header "Waiting on:")))
              (org-ql-block '(and (todo)
                                  (not (scheduled))
-                                 (not (todo "WAITING"))
+                                 (not (todo "HOLD" "WAITING" "NEXT"))
                                  (tags "@work")
                                  (tags "charliework"))
                            ((org-ql-block-header "Charlie work:")))

--- a/stow/emacs/.emacs.d/init.el
+++ b/stow/emacs/.emacs.d/init.el
@@ -959,6 +959,18 @@ Redefined to allow pop-up windows."
 
 ;;; LSP
 
+(use-package flycheck
+  :ghook ('after-init-hook #'global-flycheck-mode)
+  :init (gsetq flycheck-display-errors-delay 0.2)
+  :config
+  (general-def 'normal flycheck-error-list-mode
+    "q" #'quit-window)
+
+  (general-m 'normal flycheck-mode-map
+    "E" #'flycheck-list-errors
+    "j" #'flycheck-next-error
+    "k" #'flycheck-previous-error))
+
 (use-package lsp-mode
   :hook ((scala-mode  . lsp-deferred)
          (python-mode . (lambda () (require 'lsp-python-ms)(lsp-deferred)))
@@ -976,6 +988,9 @@ Redefined to allow pop-up windows."
          lsp-idle-delay 0.5
          read-process-output-max (* 1024 1024))
   :config
+  ;; Not sure why this is needed, but Flycheck never initializes unless this is called
+  (require 'lsp-diagnostics)
+
   ;; TODO figure out why these bindings don't take effect unless manually evaluating
   ;; `evil-normal-state' in the relevant buffer. Current behavior is as follows:
   ;;
@@ -997,7 +1012,7 @@ Redefined to allow pop-up windows."
 
   (general-m lsp-mode-map
     "m" lsp-command-map
-    "R" #'lsp-restart-workspace
+    "R" #'lsp-workspace-restart
     "Q" #'lsp-workspace-shutdown
     "s" #'lsp-describe-session
     "l" #'lsp-workspace-show-log)

--- a/stow/emacs/.emacs.d/init.el
+++ b/stow/emacs/.emacs.d/init.el
@@ -887,6 +887,10 @@ Redefined to allow pop-up windows."
   :ghook 'org-mode-hook
   :gfhook #'(lambda () (evil-org-set-key-theme))
   :config
+  ;; Directly bind `evil-org-return' instead of messing with the `evil-org-key-theme' list
+  (general-def 'normal org-mode-map
+    "RET" #'evil-org-return)
+
   ;; Evil bindings for agenda views, too
   (require 'evil-org-agenda)
   (evil-org-agenda-set-keys))

--- a/stow/zsh/.zshenv
+++ b/stow/zsh/.zshenv
@@ -4,3 +4,6 @@
 if [ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
     . "$HOME/.nix-profile/etc/profile.d/nix.sh"
 fi
+
+export EDITOR=emacsclient
+export VISUAL=emacsclient

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -91,36 +91,9 @@ if (( $+commands[fasd] )); then
     # alias zz='fasd_cd -d -i' # cd with interactive selection
 fi
 
-# Emacs settings
-if (( $+commands[emacsclient] )); then
-    # Launches Emacs in an SMRT way
-    #
-    # First, check to see if there are any existing Emacs frames. If so, connect
-    # to the existing one. If not, create one. By going through `emacsclient` we
-    # also start the Emacs server if it isn't running.
-    #
-    # Note: the minimum number of frames required is 2. This is not a mistake. If
-    # this is set to 1, Emacs does not successfully connect to the existing frame.
-    # My best guess at explaining this is that running the Emacs daemon consumes a
-    # frame, and counting actual frames opened is 2-indexed.
-    _emacslauncher() {
-        if [[ "$(emacsclient --alternate-editor "" --eval '(length (frame-list))' 2>/dev/null)" -ge 2 ]]; then
-            emacsclient --alternate-editor "" "$@"
-        else
-            emacsclient --alternate-editor "" --create-frame "$@"
-        fi
-    }
-
-    export EDITOR='emacsclient'
-    export VISUAL='emacsclient'
-
-    alias emacs='_emacslauncher --no-wait'
-    alias e=emacs
-    alias temacs='_emacslauncher --no-wait -nw'
-    alias te=temacs
-    alias eeval='_emacslauncher --eval'
-    alias ke="_emacslauncher --eval '(kill-emacs)'"
-fi
+# Emacs aliases
+alias emacs='emacsclient --no-wait --create-frame'
+alias e=emacs
 
 # Nix aliases
 alias ns='nix-shell'


### PR DESCRIPTION
This PR simplifies how Emacs is called in `.zshenv` and `zshrc`, and depends on the following steps:

- Create a launch agent file for `launchd`
- Load the agent so that it starts on login

These steps are outside of Nix, though a suitable agent file is provided in `resources` for use. 
