### PR TITLE
Adds VictorMono Font

### DIFF
--- a/config/alacritty/alacritty.yml
+++ b/config/alacritty/alacritty.yml
@@ -131,7 +131,7 @@ font:
     #   - (macOS) Menlo
     #   - (Linux/BSD) monospace
     #   - (Windows) Consolas
-    family: FuraMono Nerd Font Mono
+    family: VictorMono Nerd Font Mono
 
     # The `style` can be specified to pick a specific face.
     style: Regular
@@ -148,18 +148,18 @@ font:
     style: Regular
 
   # Italic font face
-  #italic:
+  italic:
     # Font family
     #
     # If the italic family is not specified, it will fall back to the
     # value specified for the normal font.
-    #family: monospace
+    # family: monospace
 
     # The `style` can be specified to pick a specific face.
-    #style: Italic
+    style: Italic
 
   # Bold italic font face
-  #bold_italic:
+  bold_italic:
     # Font family
     #
     # If the bold italic family is not specified, it will fall back to the
@@ -167,7 +167,7 @@ font:
     #family: monospace
 
     # The `style` can be specified to pick a specific face.
-    #style: Bold Italic
+    style: Italic
 
   # Point size
   size: 14.0

--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -75,7 +75,7 @@
   # NOTE: this removes any manually added fonts
   fonts.fontDir.enable = true;
   fonts.fonts = with pkgs; [
-    (nerdfonts.override { fonts = [ "FiraMono" ]; })
+    (nerdfonts.override { fonts = [ "FiraMono" "VictorMono" ]; })
     source-sans-pro
   ];
 

--- a/home/adost-ltm.nix
+++ b/home/adost-ltm.nix
@@ -1,4 +1,10 @@
-{ config, lib, pkgs, ... }: {
+{ config, lib, pkgs, ... }:
+let
+  inherit (config.lib.file) mkOutOfStoreSymlink;
+
+  nixConfigDir = "/Users/adost/code/dots";
+in
+{
   # This value determines the Home Manager release that your configuration is
   # compatible with. This helps avoid breakage when a new Home Manager release
   # introduces backwards incompatible changes.
@@ -9,17 +15,16 @@
   # See https://nix-community.github.io/home-manager/release-notes.html
   home.stateVersion = "22.11";
 
-  # Dotfiles
-  # TODO: re-evaluate
+  # Dotfiles (stable)
   xdg.configFile."karabiner/karabiner.json".source = ../config/karabiner/karabiner.json;
-  xdg.configFile."alacritty/alacritty.yml".source = ../config/alacritty/alacritty.yml;
   xdg.configFile."fd/ignore".source = ../config/fd/ignore;
   xdg.configFile."direnv/direnvrc".source = ../config/direnv/direnvrc;
-  xdg.configFile."iTerm2/com.googlecode.iterm2.plist".source = ../config/iTerm2/com.googlecode.iterm2.plist;
-  xdg.configFile.nvim = {
-    source = ../config/nvim;
-    recursive = true;
-  };
+
+  # Dotfiles (unstable)
+  # This allows direct editing for testing, troubleshooting, etc.
+  # Warning: it is possible to lose configuration if changes are made and not ported to this repository
+  xdg.configFile."alacritty/alacritty.yml".source = mkOutOfStoreSymlink "${nixConfigDir}/config/alacritty/alacritty.yml";
+  xdg.configFile.nvim.source = mkOutOfStoreSymlink "${nixConfigDir}/config/nvim";
 
   # ZSH
   # https://nix-community.github.io/home-manager/options.html#opt-programs.zsh.enable


### PR DESCRIPTION
Adds the VictorMono font and configures Alacritty accordingly. Also makes Alacritty/Neovim configuration available outside the Nix store, for easier editing.
