### PR TITLE
Split Darwin Configuration

### DIFF
--- a/darwin/bootstrap.nix
+++ b/darwin/bootstrap.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, ... }: {
+{ lib, pkgs, ... }: {
   # Nix configuration
   nix.settings = {
     trusted-users = [ "@admin" ];

--- a/darwin/bootstrap.nix
+++ b/darwin/bootstrap.nix
@@ -1,0 +1,40 @@
+{ config, lib, pkgs, ... }: {
+  # Nix configuration
+  nix.settings = {
+    trusted-users = [ "@admin" ];
+
+    experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
+
+    extra-platforms = lib.mkIf (pkgs.system == "aarch64-darwin") [
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+
+    # Recommended when using `direnv` etc.
+    keep-derivations = true;
+    keep-outputs = true;
+  };
+
+  # Enable configuration for `nixbld` group and users
+  nix.configureBuildUsers = true;
+
+  # Auto upgrade nix package and the daemon service
+  services.nix-daemon.enable = true;
+
+  # Add shells installed by nix to `/etc/shells`
+  environment.shells = with pkgs; [
+    bashInteractive
+    zsh
+  ];
+
+  # Install and setup ZSH to work with nix(-darwin)
+  programs.zsh.enable = true;
+  environment.variables.SHELL = "${pkgs.zsh}/bin/zsh";
+
+  # Used for backwards compatibility, please read the changelog before changing.
+  # $ darwin-rebuild changelog
+  system.stateVersion = 4;
+}

--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -1,42 +1,4 @@
-{ config, lib, pkgs, ... }: {
-  # Apps
-  # `home-manager` currently has issues adding them to `~/Applications`
-  # Issue: https://github.com/nix-community/home-manager/issues/1341
-  environment.systemPackages = with pkgs; [
-    unstable.alacritty
-  ];
-
-  # Nix-darwin does not link installed applications to the user environment.
-  # This means apps will not show up in spotlight, and when launched through
-  # the dock they come with a terminal window. This is a workaround.
-  # Upstream issue: https://github.com/LnL7/nix-darwin/issues/214
-  system.activationScripts.applications.text = lib.mkForce ''
-    echo "setting up /Applications/Nix Apps" >&2
-    nix_apps="/Applications/Nix Apps"
-
-    # Delete the directory to remove old links
-    rm -rf "$nix_apps"
-    mkdir -p "$nix_apps"
-
-    find ${config.system.build.applications}/Applications -maxdepth 1 -type l -exec readlink '{}' + |
-      while read src; do
-        # Spotlight does not recognize symlinks, it will ignore directory we
-        # link to the applications folder. It does understand MacOS aliases
-        # though, a unique filesystem feature. Sadly they cannot be created
-        # from bash (as far as I know), so we use the oh-so-great Apple Script
-        # instead.
-        /usr/bin/osascript -e "
-            set fileToAlias to POSIX file \"$src\"
-            set applicationsFolder to POSIX file \"$nix_apps\"
-            tell application \"Finder\"
-                make alias file to fileToAlias at applicationsFolder
-                # This renames the alias; 'mpv.app alias' -> 'mpv.app'
-                set name of result to \"$(rev <<< "$src" | cut -d'/' -f1 | rev)\"
-            end tell
-        " 1>/dev/null
-      done
-  '';
-
+{ pkgs, ... }: {
   # Fonts
   # NOTE: this removes any manually added fonts
   fonts.fontDir.enable = true;

--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -1,38 +1,4 @@
 { config, lib, pkgs, ... }: {
-  # Nix configuration
-  nix.settings = {
-    trusted-users = [ "@admin" ];
-
-    experimental-features = [
-      "nix-command"
-      "flakes"
-    ];
-
-    extra-platforms = lib.mkIf (pkgs.system == "aarch64-darwin") [
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ];
-
-    # Recommended when using `direnv` etc.
-    keep-derivations = true;
-    keep-outputs = true;
-  };
-
-  # Enable configuration for `nixbld` group and users
-  nix.configureBuildUsers = true;
-
-  # Auto upgrade nix package and the daemon service
-  services.nix-daemon.enable = true;
-
-  # Add shells installed by nix to `/etc/shells`
-  environment.shells = with pkgs; [
-    bashInteractive
-    zsh
-  ];
-
-  # Install and setup ZSH to work with nix(-darwin)
-  programs.zsh.enable = true;
-
   # Apps
   # `home-manager` currently has issues adding them to `~/Applications`
   # Issue: https://github.com/nix-community/home-manager/issues/1341
@@ -78,8 +44,4 @@
     (nerdfonts.override { fonts = [ "FiraMono" "IBMPlexMono" ]; })
     source-sans-pro
   ];
-
-  # Used for backwards compatibility, please read the changelog before changing.
-  # $ darwin-rebuild changelog
-  system.stateVersion = 4;
 }

--- a/darwin/defaults.nix
+++ b/darwin/defaults.nix
@@ -1,0 +1,27 @@
+{
+  system.defaults.NSGlobalDomain = {
+    # Keyboard behavior
+    InitialKeyRepeat = 10;
+    KeyRepeat = 1;
+    "com.apple.keyboard.fnState" = true;
+
+    # Trackpad behavior
+    "com.apple.trackpad.scaling" = 3.0;
+    "com.apple.swipescrolldirection" = false;
+
+    # Miscellaneous
+    AppleICUForce24HourTime = true;
+    AppleInterfaceStyle = "Dark";
+    AppleShowAllExtensions = true;
+    AppleShowScrollBars = "Automatic";
+    NSAutomaticCapitalizationEnabled = false;
+    NSAutomaticDashSubstitutionEnabled = false;
+    NSAutomaticPeriodSubstitutionEnabled = false;
+    NSAutomaticQuoteSubstitutionEnabled = false;
+    NSAutomaticSpellingCorrectionEnabled = false;
+    NSTableViewDefaultSizeMode = 1;
+    _HIHideMenuBar = true;
+    "com.apple.springing.delay" = 0.0;
+    "com.apple.springing.enabled" = true;
+  };
+}

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -1,0 +1,41 @@
+{ config, lib, ... }:
+let
+  inherit (lib) mkIf;
+  brewEnabled = config.homebrew.enable;
+in
+{
+  environment.shellInit = mkIf brewEnabled ''
+    eval "$(${config.homebrew.brewPrefix}/brew shellenv)"
+  '';
+
+  homebrew.enable = true;
+  homebrew.onActivation.autoUpdate = true;
+  homebrew.onActivation.cleanup = "zap";
+  homebrew.global.brewfile = true;
+
+  homebrew.taps = [
+    "homebrew/bundle"
+    "homebrew/cask"
+    "homebrew/core"
+    "nrlquaker/createzap"
+  ];
+
+  # Prefer applications from the Mac App Store
+  homebrew.masApps = {
+  };
+
+  # Use Homebrew Casks for applications not available in the Mac App Store
+  #
+  # Note: apps installed via Homebrew are Spotlight-indexed, whereas those
+  # installed via nix-darwin or home-manager are not, by default.
+  homebrew.casks = [
+    "alacritty"
+  ];
+
+  # A last resort; for packages that aren't available (or broken) in `nixpkgs`
+  homebrew.brews = [
+    "poetry"
+    "pyenv"
+  ];
+}
+

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -22,6 +22,8 @@ in
 
   # Prefer applications from the Mac App Store
   homebrew.masApps = {
+    Slack = 803453959;
+    "Things 3" = 904280696;
   };
 
   # Use Homebrew Casks for applications not available in the Mac App Store
@@ -30,6 +32,10 @@ in
   # installed via nix-darwin or home-manager are not, by default.
   homebrew.casks = [
     "alacritty"
+    "karabiner-elements"
+    "obsidian"
+    "signal"
+    "spotify"
   ];
 
   # A last resort; for packages that aren't available (or broken) in `nixpkgs`

--- a/flake.nix
+++ b/flake.nix
@@ -52,11 +52,15 @@
         };
       };
 
+      darwinModules = {
+        bootstrap = import ./darwin/bootstrap.nix;
+        configuration = import ./darwin/configuration.nix;
+      };
+
       darwinConfigurations = {
         adost-ltm = darwinSystem {
           system = "x86_64-darwin";
-          modules = [
-            ./darwin/configuration.nix
+          modules = attrValues self.darwinModules ++ [
             home-manager.darwinModules.home-manager
             {
               nixpkgs = nixpkgsConfig;

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,7 @@
 
       darwinModules = {
         bootstrap = import ./darwin/bootstrap.nix;
+        defaults = import ./darwin/defaults.nix;
         configuration = import ./darwin/configuration.nix;
         homebrew = import ./darwin/homebrew.nix;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,7 @@
       darwinModules = {
         bootstrap = import ./darwin/bootstrap.nix;
         configuration = import ./darwin/configuration.nix;
+        homebrew = import ./darwin/homebrew.nix;
       };
 
       darwinConfigurations = {


### PR DESCRIPTION
Refactors Darwin configuration into the following files:

- bootstrap.nix - minimal darwin settings, ie. for build agents, etc.
- defaults.nix - system defaults
- configuration.nix - general system configuration
- homebrew.nix - homebrew/app store configuration and packages

