### PR TITLE
Removes Stable Nixpkgs

### DIFF
--- a/config/nvim/lua/dostinthemachine/plugins/coding.lua
+++ b/config/nvim/lua/dostinthemachine/plugins/coding.lua
@@ -7,7 +7,7 @@ return {
     "numToStr/Comment.nvim",
     event = "VeryLazy",
     dependencies = {
-      { "nvim-tresitter/nvim-treesitter" },
+      { "nvim-treesitter/nvim-treesitter" },
       { "JoosepAlviste/nvim-ts-context-commentstring", opts = { enable_autocmd = false } },
     },
     opts = function()

--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -1,14 +1,15 @@
-{pkgs, ...}: {
+{ pkgs, ... }: {
   # Fonts
   # NOTE: this removes any manually added fonts
   fonts.fontDir.enable = true;
   fonts.fonts = with pkgs; [
     cooper-hewitt
-    (nerdfonts.override {fonts = ["FiraMono" "FiraCode" "IBMPlexMono"];})
+    (nerdfonts.override { fonts = [ "FiraMono" "FiraCode" "IBMPlexMono" ]; })
     source-sans
     source-serif
   ];
 
   # Enable sudo authentication with Touch ID
+  # TODO: implement a module to add full path to 'pam_reattach'
   security.pam.enableSudoTouchIdAuth = true;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -7,114 +7,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1716240091,
-        "narHash": "sha256-++gJuNv0X8naF1VkaO2sAiM3T4wLx1NtdfubEsRzX7U=",
+        "lastModified": 1716993688,
+        "narHash": "sha256-vo5k2wQekfeoq/2aleQkBN41dQiQHNTniZeVONWiWLs=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "8bf083c992e2bc0a8c07f5860d3866739b698883",
+        "rev": "c0d5b8c54d6828516c97f6be9f2d00c63a363df4",
         "type": "github"
       },
       "original": {
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "neovim-nightly-overlay",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1714641030,
-        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "neovim-nightly-overlay",
-          "hercules-ci-effects",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
-        "type": "github"
-      },
-      "original": {
-        "id": "flake-parts",
-        "type": "indirect"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "hercules-ci-effects": {
-      "inputs": {
-        "flake-parts": "flake-parts_2",
-        "nixpkgs": [
-          "neovim-nightly-overlay",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1713898448,
-        "narHash": "sha256-6q6ojsp/Z9P2goqnxyfCSzFOD92T3Uobmj8oVAicUOs=",
-        "owner": "hercules-ci",
-        "repo": "hercules-ci-effects",
-        "rev": "c0302ec12d569532a6b6bd218f698bc402e93adc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "hercules-ci-effects",
         "type": "github"
       }
     },
@@ -125,74 +27,26 @@
         ]
       },
       "locked": {
-        "lastModified": 1715930644,
-        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
+        "lastModified": 1717052710,
+        "narHash": "sha256-LRhOxzXmOza5SymhOgnEzA8EAQp+94kkeUYWKKpLJ/U=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
+        "rev": "29c69d9a466e41d46fd3a7a9d0591ef9c113c2ae",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "neovim-flake": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "neovim-nightly-overlay",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "dir": "contrib",
-        "lastModified": 1715815279,
-        "narHash": "sha256-Pf7ZlqPnr195NZb5ADzMVsXurPMjRZ+JMXf6JxvXArE=",
-        "owner": "neovim",
-        "repo": "neovim",
-        "rev": "9ca81b025990911c2a0dbda92af39ba84983bac3",
-        "type": "github"
-      },
-      "original": {
-        "dir": "contrib",
-        "owner": "neovim",
-        "repo": "neovim",
-        "type": "github"
-      }
-    },
-    "neovim-nightly-overlay": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
-        "hercules-ci-effects": "hercules-ci-effects",
-        "neovim-flake": "neovim-flake",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1715817852,
-        "narHash": "sha256-UH5o7hT72oAavJTG2NxlpMyQe3BQMniQAsgTugWtlc4=",
-        "owner": "nix-community",
-        "repo": "neovim-nightly-overlay",
-        "rev": "7b5ca2486bba58cac80b9229209239740b67cf90",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "neovim-nightly-overlay",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716220750,
-        "narHash": "sha256-Lhhrd1ZBNXCbUupWGq6gRPIy1qMKEdcAXcjnwgVqe/U=",
+        "lastModified": 1716977081,
+        "narHash": "sha256-pFe5jLeIPlKEln5n2h998d7cpzXFdbrBMRe3suz4K1o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "641daa314d5bc1bca4b345da8eb08a130b109c79",
+        "rev": "ac82a513e55582291805d6f09d35b6d8b60637a1",
         "type": "github"
       },
       "original": {
@@ -202,43 +56,11 @@
         "type": "github"
       }
     },
-    "nvim-tree": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1715647490,
-        "narHash": "sha256-YqHAEztx6gEEm0GoDXC5djnIP030oGGRcskp8LPqVoc=",
-        "owner": "nvim-tree",
-        "repo": "nvim-tree.lua",
-        "rev": "2bc725a3ebc23f0172fb0ab4d1134b81bcc13812",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nvim-tree",
-        "repo": "nvim-tree.lua",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "darwin": "darwin",
         "home-manager": "home-manager",
-        "neovim-nightly-overlay": "neovim-nightly-overlay",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -7,16 +7,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1713946171,
-        "narHash": "sha256-lc75rgRQLdp4Dzogv5cfqOg6qYc5Rp83oedF2t0kDp8=",
+        "lastModified": 1716240091,
+        "narHash": "sha256-++gJuNv0X8naF1VkaO2sAiM3T4wLx1NtdfubEsRzX7U=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "230a197063de9287128e2c68a7a4b0cd7d0b50a7",
+        "rev": "8bf083c992e2bc0a8c07f5860d3866739b698883",
         "type": "github"
       },
       "original": {
         "owner": "lnl7",
-        "ref": "master",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -126,16 +125,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1714043624,
-        "narHash": "sha256-Xn2r0Jv95TswvPlvamCC46wwNo8ALjRCMBJbGykdhcM=",
+        "lastModified": 1715930644,
+        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "86853e31dc1b62c6eeed11c667e8cdd0285d4411",
+        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-23.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -150,11 +148,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1715728713,
-        "narHash": "sha256-DmODP02EhM3+O2hHKB+AVJc+5qykxDh8nz7POO6zGrI=",
+        "lastModified": 1715815279,
+        "narHash": "sha256-Pf7ZlqPnr195NZb5ADzMVsXurPMjRZ+JMXf6JxvXArE=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "7acf39ddab8ebdb63ebf78ec980149d20783fd4b",
+        "rev": "9ca81b025990911c2a0dbda92af39ba84983bac3",
         "type": "github"
       },
       "original": {
@@ -171,15 +169,15 @@
         "hercules-ci-effects": "hercules-ci-effects",
         "neovim-flake": "neovim-flake",
         "nixpkgs": [
-          "nixpkgs-unstable"
+          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1715731444,
-        "narHash": "sha256-Mdj0NXU5yZCyX8LWigox+ab67RQGcYpmbuw3NQr6L9E=",
+        "lastModified": 1715817852,
+        "narHash": "sha256-UH5o7hT72oAavJTG2NxlpMyQe3BQMniQAsgTugWtlc4=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "5c17e8ef097ee948586858a25e05bc48145a2956",
+        "rev": "7b5ca2486bba58cac80b9229209239740b67cf90",
         "type": "github"
       },
       "original": {
@@ -190,27 +188,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715359504,
-        "narHash": "sha256-tvnZKS6qR/QZXbq6rb37z3/3cC6mEl+YqFSjAuTsYa0=",
+        "lastModified": 1716220750,
+        "narHash": "sha256-Lhhrd1ZBNXCbUupWGq6gRPIy1qMKEdcAXcjnwgVqe/U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ac4d26706c8ff1e6395936a2fd2884ab06c78b12",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-23.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1715220225,
-        "narHash": "sha256-X0xvboLSjfC5s/M1yuPdSdc6yzKV8536hTTWCSKF5Xc=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "ac34158a823c7596e0106c806d0b7df47885fa73",
+        "rev": "641daa314d5bc1bca4b345da8eb08a130b109c79",
         "type": "github"
       },
       "original": {
@@ -241,9 +223,7 @@
         "darwin": "darwin",
         "home-manager": "home-manager",
         "neovim-nightly-overlay": "neovim-nightly-overlay",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "nvim-tree": "nvim-tree"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,62 +16,31 @@
     neovim-nightly-overlay.url = "github:nix-community/neovim-nightly-overlay";
     neovim-nightly-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
-  outputs = {
-    self,
-    nixpkgs,
-    darwin,
-    home-manager,
-    neovim-nightly-overlay,
-    ...
-  } @ inputs: let
-    inherit (darwin.lib) darwinSystem;
-    inherit (inputs.nixpkgs.lib) attrValues optionalAttrs singleton;
+  outputs =
+    { self
+    , nixpkgs
+    , darwin
+    , home-manager
+    , neovim-nightly-overlay
+    , ...
+    } @ inputs:
+    let
+      inherit (darwin.lib) darwinSystem;
+      inherit (inputs.nixpkgs.lib) attrValues;
 
       currentSystem = "x86_64-darwin";
 
-    # Configuration for 'nixpkgs'
-    nixpkgsConfig = {
-      config = {allowUnfree = true;};
-      overlays = singleton neovim-nightly-overlay.overlay;
-    };
-  in {
-    overlays = {
-      # # Adds access to x86 packages through 'pkgs.x86' if running Apple Silicon
-      # apple-silicon = _: prev: optionalAttrs (prev.stdenv.system == "aarch64-darwin") {
-      #   x86 = import inputs.nixpkgs {
-      #     system = "x86_64-darwin";
-      #     inherit (nixpkgsConfig) config;
-      #   };
-      # };
-
-      # # Substitute x86 versions of packages that don't build on Apple Silicon yet
-      # sub-x86 = final: prev: optionalAttrs (prev.stdenv.system == "aarch64-darwin") {
-      #   inherit (final.x86);
-      # };
-    };
-
-    darwinModules = {
-      bootstrap = import ./darwin/bootstrap.nix;
-      defaults = import ./darwin/defaults.nix;
-      configuration = import ./darwin/configuration.nix;
-      homebrew = import ./darwin/homebrew.nix;
-    };
-
-    darwinConfigurations = {
-      adost-ltm = darwinSystem {
-        system = "x86_64-darwin";
-        modules =
-          attrValues self.darwinModules
-          ++ [
-            inputs.neovim-nightly-overlay.overlay
-          ];
+      # Configuration for 'nixpkgs'
+      nixpkgsConfig = {
+        config = { allowUnfree = true; };
+        overlays = [ neovim-nightly-overlay.overlay ];
       };
     in
     {
       overlays = {
-        # # Adds access to (unstable) x86 packages through 'pkgs.x86' if running Apple Silicon
+        # # Adds access to x86 packages through 'pkgs.x86' if running Apple Silicon
         # apple-silicon = _: prev: optionalAttrs (prev.stdenv.system == "aarch64-darwin") {
-        #   x86 = import inputs.nixpkgs-unstable {
+        #   x86 = import inputs.nixpkgs {
         #     system = "x86_64-darwin";
         #     inherit (nixpkgsConfig) config;
         #   };
@@ -81,31 +50,6 @@
         # sub-x86 = final: prev: optionalAttrs (prev.stdenv.system == "aarch64-darwin") {
         #   inherit (final.x86);
         # };
-
-        # Adds access to unstable packages through 'pkgs.unstable'
-        pkgs-unstable = _: prev: {
-          unstable = import inputs.nixpkgs-unstable {
-            inherit (prev.stdenv) system;
-            inherit (nixpkgsConfig) config;
-          };
-        };
-
-        # Adds Neovim plugins not in `nixpkgs`
-        nvim-plugins = final: prev:
-          let
-            nvim-tree = prev.vimUtils.buildVimPlugin rec {
-              name = "nvim-tree";
-              src = inputs.nvim-tree;
-              version = src.lastModifiedDate;
-            };
-          in
-          {
-            vimPlugins =
-              prev.vimPlugins
-              // {
-                inherit nvim-tree;
-              };
-          };
       };
 
       darwinModules = {

--- a/flake.nix
+++ b/flake.nix
@@ -11,17 +11,12 @@
     # Home manager
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
-
-    # Neovim nightly build
-    neovim-nightly-overlay.url = "github:nix-community/neovim-nightly-overlay";
-    neovim-nightly-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
   outputs =
     { self
     , nixpkgs
     , darwin
     , home-manager
-    , neovim-nightly-overlay
     , ...
     } @ inputs:
     let
@@ -33,7 +28,7 @@
       # Configuration for 'nixpkgs'
       nixpkgsConfig = {
         config = { allowUnfree = true; };
-        overlays = [ neovim-nightly-overlay.overlay ];
+        overlays = attrValues self.overlays ++ [];
       };
     in
     {

--- a/flake.nix
+++ b/flake.nix
@@ -16,24 +16,60 @@
     neovim-nightly-overlay.url = "github:nix-community/neovim-nightly-overlay";
     neovim-nightly-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
-  outputs =
-    { self
-    , nixpkgs
-    , darwin
-    , home-manager
-    , ...
-    } @ inputs:
-    let
-      inherit (darwin.lib) darwinSystem;
-      inherit (inputs.nixpkgs.lib) attrValues optionalAttrs singleton;
+  outputs = {
+    self,
+    nixpkgs,
+    darwin,
+    home-manager,
+    neovim-nightly-overlay,
+    ...
+  } @ inputs: let
+    inherit (darwin.lib) darwinSystem;
+    inherit (inputs.nixpkgs.lib) attrValues optionalAttrs singleton;
 
       currentSystem = "x86_64-darwin";
 
-      # Configuration for 'nixpkgs'
-      nixpkgsConfig = {
-        config = { allowUnfree = true; };
-        overlays =
-          attrValues self.overlays
+    # Configuration for 'nixpkgs'
+    nixpkgsConfig = {
+      config = {allowUnfree = true;};
+      overlays = singleton neovim-nightly-overlay.overlay;
+    };
+  in {
+    overlays = {
+      # # Adds access to (unstable) x86 packages through 'pkgs.x86' if running Apple Silicon
+      # apple-silicon = _: prev: optionalAttrs (prev.stdenv.system == "aarch64-darwin") {
+      #   x86 = import inputs.nixpkgs-unstable {
+      #     system = "x86_64-darwin";
+      #     inherit (nixpkgsConfig) config;
+      #   };
+      # };
+
+      # # Substitute x86 versions of packages that don't build on Apple Silicon yet
+      # sub-x86 = final: prev: optionalAttrs (prev.stdenv.system == "aarch64-darwin") {
+      #   inherit (final.x86);
+      # };
+
+      # Adds access to unstable packages through 'pkgs.unstable'
+      pkgs-unstable = _: prev: {
+        unstable = import inputs.nixpkgs-unstable {
+          inherit (prev.stdenv) system;
+          inherit (nixpkgsConfig) config;
+        };
+      };
+    };
+
+    darwinModules = {
+      bootstrap = import ./darwin/bootstrap.nix;
+      defaults = import ./darwin/defaults.nix;
+      configuration = import ./darwin/configuration.nix;
+      homebrew = import ./darwin/homebrew.nix;
+    };
+
+    darwinConfigurations = {
+      adost-ltm = darwinSystem {
+        system = "x86_64-darwin";
+        modules =
+          attrValues self.darwinModules
           ++ [
             inputs.neovim-nightly-overlay.overlay
           ];

--- a/flake.nix
+++ b/flake.nix
@@ -2,27 +2,19 @@
   description = "Ascander's darwin system";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-23.11-darwin";
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
-    darwin.url = "github:lnl7/nix-darwin/master";
+    # Nix darwin
+    darwin.url = "github:lnl7/nix-darwin";
     darwin.inputs.nixpkgs.follows = "nixpkgs";
 
-    # Use the `home-manager` branch corresponding to the 'nixpkgs' branch
-    #
-    # See: https://github.com/nix-community/home-manager/issues/3928
-    home-manager.url = "github:nix-community/home-manager/release-23.11";
+    # Home manager
+    home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
     # Neovim nightly build
     neovim-nightly-overlay.url = "github:nix-community/neovim-nightly-overlay";
-    neovim-nightly-overlay.inputs.nixpkgs.follows = "nixpkgs-unstable";
-
-    # Neovim plugins
-    nvim-tree = {
-      url = "github:nvim-tree/nvim-tree.lua";
-      flake = false;
-    };
+    neovim-nightly-overlay.inputs.nixpkgs.follows = "nixpkgs";
   };
   outputs =
     { self

--- a/flake.nix
+++ b/flake.nix
@@ -36,9 +36,9 @@
     };
   in {
     overlays = {
-      # # Adds access to (unstable) x86 packages through 'pkgs.x86' if running Apple Silicon
+      # # Adds access to x86 packages through 'pkgs.x86' if running Apple Silicon
       # apple-silicon = _: prev: optionalAttrs (prev.stdenv.system == "aarch64-darwin") {
-      #   x86 = import inputs.nixpkgs-unstable {
+      #   x86 = import inputs.nixpkgs {
       #     system = "x86_64-darwin";
       #     inherit (nixpkgsConfig) config;
       #   };
@@ -48,14 +48,6 @@
       # sub-x86 = final: prev: optionalAttrs (prev.stdenv.system == "aarch64-darwin") {
       #   inherit (final.x86);
       # };
-
-      # Adds access to unstable packages through 'pkgs.unstable'
-      pkgs-unstable = _: prev: {
-        unstable = import inputs.nixpkgs-unstable {
-          inherit (prev.stdenv) system;
-          inherit (nixpkgsConfig) config;
-        };
-      };
     };
 
     darwinModules = {

--- a/home/home.nix
+++ b/home/home.nix
@@ -110,28 +110,28 @@ in
     terminal = "tmux-256color";
     escapeTime = 10;
     plugins = with pkgs;
-    with tmuxPlugins; [
-      {
-        plugin = fingers;
-        extraConfig = "set -g @fingers-main-action 'pbcopy'";
-      }
-      {
-        plugin = power-theme;
-        extraConfig = "set -g @tmux_power_theme 'default'";
-      }
-      {
-        plugin = resurrect;
-        extraConfig = "set -g @resurrect-strategy-nvim 'session'";
-      }
-      # FIXME: troubleshoot weirdness around duplicate sessions
-      # {
-      #   plugin = continuum;
-      #   extraConfig = ''
-      #     set -g @continuum-restore 'on'
-      #     set -g @continuum-save-interval '60' # minutes
-      #   '';
-      # }
-    ];
+      with tmuxPlugins; [
+        {
+          plugin = fingers;
+          extraConfig = "set -g @fingers-main-action 'pbcopy'";
+        }
+        {
+          plugin = power-theme;
+          extraConfig = "set -g @tmux_power_theme 'default'";
+        }
+        {
+          plugin = resurrect;
+          extraConfig = "set -g @resurrect-strategy-nvim 'session'";
+        }
+        # FIXME: troubleshoot weirdness around duplicate sessions
+        # {
+        #   plugin = continuum;
+        #   extraConfig = ''
+        #     set -g @continuum-restore 'on'
+        #     set -g @continuum-save-interval '60' # minutes
+        #   '';
+        # }
+      ];
     extraConfig = builtins.readFile ../config/tmux/tmux.conf;
   };
 
@@ -215,15 +215,12 @@ in
     withNodeJs = false;
     withPython3 = true;
     withRuby = false;
-    # Plugins
-    plugins = with pkgs;
-    with vimPlugins; [
-      vim-tmux-navigator
-    ];
-    # Command line utilities, language servers, etc.
     extraPackages = with pkgs; [
-      ripgrep
-      tree-sitter
+      coursier
+      nodejs_22
+      python311Packages.pynvim
+      nixd
+      wget
     ];
   };
 
@@ -251,6 +248,7 @@ in
     bat
     coursier
     delta
+    eza
     fd
     fzf
     gawk
@@ -261,23 +259,11 @@ in
     gtop
     httpie
     jq
-    pstree
-    tree
-    eza
-    zoxide
-
-    # Neovim requirements
-    glow
-    reattach-to-user-namespace
-    stylua
     lazygit
-
-    # Language servers
-    nil
-    nodePackages.bash-language-server
-    nodePackages.yaml-language-server
-    pyright
-    lua-language-server
+    pstree
+    reattach-to-user-namespace
+    tree
+    zoxide
 
     # Misc
     pinentry_mac

--- a/home/home.nix
+++ b/home/home.nix
@@ -102,7 +102,6 @@ in
   # See: https://gpanders.com/blog/the-definitive-guide-to-using-tmux-256color-on-macos/
   programs.tmux = {
     enable = true;
-    package = pkgs.unstable.tmux;
     clock24 = true;
     keyMode = "vi";
     mouse = true;

--- a/home/home.nix
+++ b/home/home.nix
@@ -205,12 +205,10 @@ in
 
   # Neovim
   # https://nix-community.github.io/home-manager/options.xhtml#opt-programs.neovim.enable
-  # https://github.com/nix-community/neovim-nightly-overlay
   #
   # NOTE: plugin management is handled by `lazy.nvim` outside of Nix. Why be coy? 🤷
   programs.neovim = {
     enable = true;
-    package = pkgs.neovim-nightly;
     defaultEditor = true;
     withNodeJs = false;
     withPython3 = true;

--- a/home/home.nix
+++ b/home/home.nix
@@ -73,7 +73,7 @@ in
       GPG_TTY = "$(tty)";
 
       XDG_CONFIG_HOME = "$HOME/.config";
-      TERMINFO_DIRS = "$HOME/.local/share/terminfo:${pkgs.unstable.alacritty.terminfo.outPath}/share/terminfo";
+      TERMINFO_DIRS = "$HOME/.local/share/terminfo:${pkgs.alacritty.terminfo.outPath}/share/terminfo";
     };
     initExtra = builtins.readFile ../config/zsh/.zshrc;
   };
@@ -82,7 +82,6 @@ in
   # https://nix-community.github.io/home-manager/options.xhtml#opt-programs.starship.enable
   programs.starship = {
     enable = true;
-    package = pkgs.unstable.starship;
     settings = builtins.fromTOML (builtins.readFile ../config/starship/starship.toml);
   };
 
@@ -110,29 +109,29 @@ in
     shortcut = "a";
     terminal = "tmux-256color";
     escapeTime = 10;
-    plugins = with pkgs.unstable;
-      with tmuxPlugins; [
-        {
-          plugin = fingers;
-          extraConfig = "set -g @fingers-main-action 'pbcopy'";
-        }
-        {
-          plugin = power-theme;
-          extraConfig = "set -g @tmux_power_theme 'default'";
-        }
-        {
-          plugin = resurrect;
-          extraConfig = "set -g @resurrect-strategy-nvim 'session'";
-        }
-        # FIXME: troubleshoot weirdness around duplicate sessions
-        # {
-        #   plugin = continuum;
-        #   extraConfig = ''
-        #     set -g @continuum-restore 'on'
-        #     set -g @continuum-save-interval '60' # minutes
-        #   '';
-        # }
-      ];
+    plugins = with pkgs;
+    with tmuxPlugins; [
+      {
+        plugin = fingers;
+        extraConfig = "set -g @fingers-main-action 'pbcopy'";
+      }
+      {
+        plugin = power-theme;
+        extraConfig = "set -g @tmux_power_theme 'default'";
+      }
+      {
+        plugin = resurrect;
+        extraConfig = "set -g @resurrect-strategy-nvim 'session'";
+      }
+      # FIXME: troubleshoot weirdness around duplicate sessions
+      # {
+      #   plugin = continuum;
+      #   extraConfig = ''
+      #     set -g @continuum-restore 'on'
+      #     set -g @continuum-save-interval '60' # minutes
+      #   '';
+      # }
+    ];
     extraConfig = builtins.readFile ../config/tmux/tmux.conf;
   };
 
@@ -216,12 +215,15 @@ in
     withNodeJs = false;
     withPython3 = true;
     withRuby = false;
-    extraPackages = with pkgs.unstable; [
-      coursier
-      nodejs_22
-      python311Packages.pynvim
-      nixd # not available in the Mason registry
-      wget
+    # Plugins
+    plugins = with pkgs;
+    with vimPlugins; [
+      vim-tmux-navigator
+    ];
+    # Command line utilities, language servers, etc.
+    extraPackages = with pkgs; [
+      ripgrep
+      tree-sitter
     ];
   };
 
@@ -261,15 +263,21 @@ in
     jq
     pstree
     tree
-    unstable.eza
+    eza
     zoxide
 
     # Neovim requirements
     glow
     reattach-to-user-namespace
-    ripgrep
-    tree-sitter
-    unstable.lazygit
+    stylua
+    lazygit
+
+    # Language servers
+    nil
+    nodePackages.bash-language-server
+    nodePackages.yaml-language-server
+    pyright
+    lua-language-server
 
     # Misc
     pinentry_mac

--- a/home/home.nix
+++ b/home/home.nix
@@ -265,6 +265,7 @@ in
     zoxide
 
     # Misc
+    pam-reattach # allows use of 'pam_tid' module in tmux
     pinentry_mac
   ];
 }

--- a/home/home.nix
+++ b/home/home.nix
@@ -214,9 +214,10 @@ in
     withRuby = false;
     extraPackages = with pkgs; [
       coursier
+      nixd
       nodejs_22
       python311Packages.pynvim
-      nixd
+      tree-sitter
       wget
     ];
   };
@@ -259,6 +260,7 @@ in
     lazygit
     pstree
     reattach-to-user-namespace
+    ripgrep
     tree
     zoxide
 

--- a/home/home.nix
+++ b/home/home.nix
@@ -36,7 +36,9 @@ in
   # https://nix-community.github.io/home-manager/options.xhtml#opt-programs.zsh.enable
   programs.zsh = {
     enable = true;
-    enableAutosuggestions = true;
+    autosuggestion = {
+      enable = true;
+    };
     enableCompletion = true;
     syntaxHighlighting = {
       enable = true;


### PR DESCRIPTION
- **Removes distinct nixpkgs-unstable input**
- **Plumbs neovim nightly overlay**
- **Updates flake overlays**
- **Updates all inputs**
- **Updates ZSH config**
- **Removes references to 'pkgs.unstable'**
- **Fixes merge conflict resolution**
- **Cleans up package set**
- **Fixes typo**
- **Removes neovim nightly overlay**
- **Removes tmux package (no longer needed)**
- **Adds commands for Neovim**
- **Adds pam-reattach for touch ID in tmux**

This PR removes stable nixpkgs in favor of nixpkgs-unstable. Associated overlays are also cleaned up. Since Neovim 0.10.0 has hit nixpkgs-unstable, we also drop the Neovim nightly overlay, which builds but is super buggy to use. One last addition is the `pam-reattach` package, which provides a fix for using Touch ID in tmux. Linking the module is manual:

```sh
ln -s /nix/store/<hash>-pam_reattach-1.3/lib/pam/pam_reattach.so /usr/local/lib/pam/pam_reattach.so
```

and the Nix store path will change with updates. The long term solution is to implement my own darwin module for pam, which adds the relevant line to `/etc/pam.d/sudo` so that a full path to the nix store can happen.
